### PR TITLE
[TIDESK-665] Modify Host::Exit()

### DIFF
--- a/libkroll/host.cpp
+++ b/libkroll/host.cpp
@@ -667,19 +667,19 @@ namespace kroll
 		shutdown = true;
 	}
 
-	void Host::Exit(int exitCode)
+	bool Host::Exit(int exitCode)
 	{
-		logger->Notice("Received exit signal (%d)", exitCode);
-		if (!GlobalObject::GetInstance()->FireEvent(Event::EXIT) ||
-			!GlobalObject::GetInstance()->FireEvent(Event::APP_EXIT))
-		{
-			logger->Notice("Exit signal canceled by event handler");
-			return;
-		}
+		GlobalObject* global = GlobalObject::GetInstance();
+
+		// Notify event listeners the application is exiting.
+		// If any listener aborts the event, stop the exit process now.
+		if (!global->FireEvent(Event::EXIT) || !global->FireEvent(Event::APP_EXIT))
+			return false;
 
 		this->exitCode = exitCode;
 		this->exiting = true;
 		this->ExitImpl(exitCode);
+		return true;
 	}
 
 	KValueRef Host::RunOnMainThread(KMethodRef method, const ValueList& args,

--- a/libkroll/host.h
+++ b/libkroll/host.h
@@ -42,9 +42,10 @@ namespace kroll
 		int Run();
 
 		/**
-		 * Called to exit the host and terminate the process
+		 * Called to exit the host and terminate the process.
+		 * If false is returned the exit should be aborted.
 		 */
-		void Exit(int exitcode);
+		bool Exit(int exitcode);
 
 		/*
 		 * Call with a method and arguments to invoke the method on the UI thread.


### PR DESCRIPTION
Exit() now returns false if the exit was aborted
by an event listener.